### PR TITLE
Fix compatibility with symfony 5.2

### DIFF
--- a/src/Make/MakeMethod.php
+++ b/src/Make/MakeMethod.php
@@ -23,13 +23,21 @@ class MakeMethod extends AbstractMaker
         return 'make:method';
     }
 
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new JSON-RPC method';
+    }
+
     /**
      * {@inheritdoc}
      */
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new JSON-RPC method')
             ->addArgument('name', InputArgument::OPTIONAL, \sprintf('Choose a method name (e.g. <fg=yellow>%s</>)', Str::getRandomTerm()))
             ->setHelp(
                 <<<EOT

--- a/src/Make/MakeMethod.php
+++ b/src/Make/MakeMethod.php
@@ -23,7 +23,6 @@ class MakeMethod extends AbstractMaker
         return 'make:method';
     }
 
-
     /**
      * {@inheritdoc}
      */

--- a/src/Make/MakeMethod.php
+++ b/src/Make/MakeMethod.php
@@ -37,6 +37,7 @@ class MakeMethod extends AbstractMaker
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
+            ->setDescription(self::getCommandDescription())
             ->addArgument('name', InputArgument::OPTIONAL, \sprintf('Choose a method name (e.g. <fg=yellow>%s</>)', Str::getRandomTerm()))
             ->setHelp(
                 <<<EOT


### PR DESCRIPTION
Fix for Symfony 5.2
`Class "Timiki\Bundle\RpcServerBundle\Make\MakeMethod" should implement method "static Symfony\Bundle\MakerBundle\MakerInterface::getCommandDescription()"`