### PR TITLE
Typed properties check

### DIFF
--- a/src/Event/JsonExecuteEvent.php
+++ b/src/Event/JsonExecuteEvent.php
@@ -16,7 +16,7 @@ class JsonExecuteEvent extends Event
         private readonly MetaData $metadata,
         private readonly MapperInterface $mapper,
         private readonly JsonRequest $jsonRequest,
-        private mixed $result
+        private mixed $result,
     ) {
     }
 

--- a/src/Event/JsonPreExecuteEvent.php
+++ b/src/Event/JsonPreExecuteEvent.php
@@ -17,7 +17,7 @@ class JsonPreExecuteEvent extends Event
         private readonly object $object,
         private readonly MetaData $metadata,
         private readonly MapperInterface $mapper,
-        private readonly JsonRequest $jsonRequest
+        private readonly JsonRequest $jsonRequest,
     ) {
     }
 

--- a/src/EventSubscriber/AuthorizationCheckerSubscriber.php
+++ b/src/EventSubscriber/AuthorizationCheckerSubscriber.php
@@ -12,7 +12,7 @@ use Timiki\Bundle\RpcServerBundle\Exceptions\MethodNotGrantedException;
 class AuthorizationCheckerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly ?AuthorizationCheckerInterface $authChecker = null
+        private readonly ?AuthorizationCheckerInterface $authChecker = null,
     ) {
     }
 

--- a/src/EventSubscriber/CacheSubscriber.php
+++ b/src/EventSubscriber/CacheSubscriber.php
@@ -13,7 +13,7 @@ use Timiki\RpcCommon\JsonResponse;
 class CacheSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly ?CacheItemPoolInterface $cacheItemPool = null
+        private readonly ?CacheItemPoolInterface $cacheItemPool = null,
     ) {
     }
 

--- a/src/EventSubscriber/ParamConverterSubscriber.php
+++ b/src/EventSubscriber/ParamConverterSubscriber.php
@@ -11,14 +11,13 @@ use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Timiki\Bundle\RpcServerBundle\Event\JsonPreExecuteEvent;
-use Timiki\Bundle\RpcServerBundle\Exceptions;
 use Timiki\Bundle\RpcServerBundle\Exceptions\InvalidParamsException;
 
 class ParamConverterSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private readonly ParameterBagInterface $parameterBag,
-        private readonly ?ValidatorInterface   $validator = null,
+        private readonly ?ValidatorInterface $validator = null,
     ) {
     }
 
@@ -62,7 +61,7 @@ class ParamConverterSubscriber implements EventSubscriberInterface
                         continue;
                     }
 
-                    throw new Exceptions\InvalidParamsException(null, $jsonRequest->getId());
+                    throw new InvalidParamsException(null, $jsonRequest->getId());
                 }
 
                 $reflectionProperty = $reflection->getProperty($name);
@@ -88,7 +87,7 @@ class ParamConverterSubscriber implements EventSubscriberInterface
         }
     }
 
-    private function checkTypes(\ReflectionType|null $reflectionType, mixed $value): ?array
+    private function checkTypes(?\ReflectionType $reflectionType, mixed $value): ?array
     {
         if (null === $reflectionType) {
             return null;
@@ -101,7 +100,7 @@ class ParamConverterSubscriber implements EventSubscriberInterface
 
         $types = [];
         if ($reflectionType instanceof \ReflectionUnionType) {
-            $types = array_map(fn($type) => $type->getName(), $reflectionType->getTypes());
+            $types = array_map(fn ($type) => $type->getName(), $reflectionType->getTypes());
         } else {
             $types[] = $reflectionType->getName();
         }
@@ -117,6 +116,6 @@ class ParamConverterSubscriber implements EventSubscriberInterface
         }
 
         /* @var ConstraintViolation $constraintViolation */
-        return array_map(fn($constraintViolation) => $constraintViolation->getMessage(), iterator_to_array($result));
+        return array_map(fn ($constraintViolation) => $constraintViolation->getMessage(), iterator_to_array($result));
     }
 }

--- a/src/EventSubscriber/ValidatorSubscriber.php
+++ b/src/EventSubscriber/ValidatorSubscriber.php
@@ -13,7 +13,7 @@ use Timiki\Bundle\RpcServerBundle\Exceptions\InvalidParamsException;
 class ValidatorSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly ?ValidatorInterface $validator = null
+        private readonly ?ValidatorInterface $validator = null,
     ) {
     }
 

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -53,6 +53,7 @@ return static function (ContainerConfigurator $container) {
     $services->set(ParamConverterSubscriber::class)
         ->args([
             service(ParameterBagInterface::class),
+            service('Symfony\Component\Validator\Validator\ValidatorInterface')->nullOnInvalid(),
         ])
         ->tag('kernel.event_subscriber');
 

--- a/src/Serializer/RoleSerializer.php
+++ b/src/Serializer/RoleSerializer.php
@@ -13,7 +13,7 @@ class RoleSerializer extends BaseSerializer implements SerializerInterface
 {
     public function __construct(
         private readonly SymfonySerializerInterface $serializer,
-        private readonly ?Security $security
+        private readonly ?Security $security,
     ) {
         parent::__construct($serializer);
     }

--- a/tests/Functional/MethodTest.php
+++ b/tests/Functional/MethodTest.php
@@ -37,6 +37,7 @@ class MethodTest extends WebTestCase
         yield 'get_context' => $this->getContext();
         yield 'get_data' => $this->getData();
         yield 'getError' => $this->getError();
+        yield 'typedProperties' => $this->typedProperties();
         yield 'multiRequests' => $this->multiRequests();
         yield 'subtractSuccess1' => $this->subtractSuccess1();
         yield 'subtractSuccess2' => $this->subtractSuccess2();
@@ -97,6 +98,129 @@ class MethodTest extends WebTestCase
         ];
 
         return $data;
+    }
+
+    private function typedProperties()
+    {
+        $data = [
+            [
+                'jsonrpc' => '2.0',
+                'method' => 'typed_properties',
+                'params' => [
+                    'int' => 10,
+                    'float' => 10.5,
+                    'bool' => true,
+                    'array' => [1, 2],
+                    'string' => 'string',
+                    'nullableString' => null,
+                    'multiType' => [],
+                    'nullableMultiType' => null,
+                ],
+                'id' => 1,
+            ],
+            [
+                'jsonrpc' => '2.0',
+                'method' => 'typed_properties',
+                'params' => [
+                    'int' => 'false',
+                    'float' => 10,
+                    'bool' => 'true',
+                    'array' => null,
+                    'string' => 10,
+                    'nullableString' => 'valid',
+                    'multiType' => null,
+                    'nullableMultiType' => 0.5,
+                ],
+                'id' => 2,
+            ],
+            [
+                'jsonrpc' => '2.0',
+                'method' => 'typed_properties',
+                'params' => [
+                    'int' => 0.1,
+                    'float' => [],
+                    'bool' => 1,
+                    'array' => [],
+                    'nullableMultiType' => true,
+                    'string' => null,
+                    'nullableString' => false,
+                    'multiType' => 'valid',
+                ],
+                'id' => 3,
+            ],
+        ];
+
+        $expected = [
+            [
+                'jsonrpc' => '2.0',
+                'result' => [
+                    10,
+                    10.5,
+                    true,
+                    [1, 2],
+                    'string',
+                    null,
+                    [],
+                    null,
+                ],
+                'id' => 1,
+            ],
+            [
+                'jsonrpc' => '2.0',
+                'error' => [
+                    'code' => -32602,
+                    'message' => 'Invalid params',
+                    'data' => [
+                        'int' => [
+                            'This value should be of type int.',
+                        ],
+                        'float' => [
+                            'This value should be of type float.',
+                        ],
+                        'bool' => [
+                            'This value should be of type bool.',
+                        ],
+                        'array' => [
+                            'This value should not be null.',
+                        ],
+                        'string' => [
+                            'This value should be of type string.',
+                        ],
+                        'multiType' => [
+                            'This value should not be null.',
+                        ],
+                    ],
+                ],
+                'id' => 2,
+            ],
+            [
+                'jsonrpc' => '2.0',
+                'error' => [
+                    'code' => -32602,
+                    'message' => 'Invalid params',
+                    'data' => [
+                        'int' => [
+                            'This value should be of type int.',
+                        ],
+                        'float' => [
+                            'This value should be of type float.',
+                        ],
+                        'bool' => [
+                            'This value should be of type bool.',
+                        ],
+                        'nullableString' => [
+                            'This value should be of type string.',
+                        ],
+                        'string' => [
+                            'This value should not be null.',
+                        ],
+                    ],
+                ],
+                'id' => 3,
+            ],
+        ];
+
+        return [$data, $expected];
     }
 
     private function multiRequests()

--- a/tests/Method/V1/TypedProperties.php
+++ b/tests/Method/V1/TypedProperties.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Timiki\Bundle\RpcServerBundle\Method\V1;
+
+use Tests\Timiki\Bundle\RpcServerBundle\Method\AbstractMethod;
+use Timiki\Bundle\RpcServerBundle\Attribute as RPC;
+
+#[RPC\Method('typed_properties')]
+class TypedProperties extends AbstractMethod
+{
+    #[RPC\Param]
+    protected int $int;
+
+    #[RPC\Param]
+    protected float $float;
+
+    #[RPC\Param]
+    protected bool $bool;
+
+    #[RPC\Param]
+    protected array $array;
+
+    #[RPC\Param]
+    protected string $string;
+
+    #[RPC\Param]
+    protected ?string $nullableString;
+
+    #[RPC\Param]
+    protected string|int|array $multiType;
+
+    #[RPC\Param]
+    protected bool|float|null $nullableMultiType;
+
+    public function __invoke(): array
+    {
+        return [
+            $this->int,
+            $this->float,
+            $this->bool,
+            $this->array,
+            $this->string,
+            $this->nullableString,
+            $this->multiType,
+            $this->nullableMultiType,
+        ];
+    }
+}


### PR DESCRIPTION
Hey,

I added an typed property check before add the request value via reflection to the class property to throw the correct errors.

Before we couldn't use typed properties and send invalid values to the method like:

```php
protected ?int $limit = 0;
```

```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "tasks",
    "params": {
        "limit": "invalid"
    }
}
```

It would throw like this:


```json
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32603,
        "message": "Cannot assign string to property App\\Rpc\\Method\\Tasks::$limit of type ?int"
    },
    "id": 1
}
```

Now we check the native types beforehand and give better errors like this:


```json
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32602,
        "message": "Invalid params",
        "data": {
            "limit": [
                "This value should be of type int."
            ]
        }
    },
    "id": 1
}
```

And finally I runned the cs-fixer.