### PR TITLE
Check default value existence

### DIFF
--- a/src/DependencyInjection/Compiler/RpcMethodPass.php
+++ b/src/DependencyInjection/Compiler/RpcMethodPass.php
@@ -122,7 +122,7 @@ class RpcMethodPass implements CompilerPassInterface
         foreach ($reflectionClass->getProperties() as $reflectionProperty) {
             $attributes = $reflectionProperty->getAttributes(Attribute\Param::class);
 
-            if (count($attributes) > 0) {
+            if (count($attributes) > 0 && $reflectionProperty->hasDefaultValue()) {
                 $meta['params'][$reflectionProperty->name] = $reflectionProperty->getDefaultValue();
             }
         }


### PR DESCRIPTION
Hey, in PHP 8.5 we get a deprecation warning, when we accessing a reflectionProperty->getDefaultValue() without defaultValue. We should check it with hasDefaultValue() before.

See details: https://github.com/php/php-src/commit/57a88b216c7057aae7beb9e6857a1a85acf2028e