### PR TITLE
Remove MakeCommand if maker is not enabled

### DIFF
--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Timiki\Bundle\RpcServerBundle\Controller\RpcController;
@@ -30,8 +31,10 @@ return static function (ContainerConfigurator $container) {
         ])
         ->tag('controller.service_arguments');
 
-    $services->set(MakeMethod::class)
-        ->tag('maker.command');
+    if (\class_exists(AbstractMaker::class)) {
+        $services->set(MakeMethod::class)
+            ->tag('maker.command');
+    }
 
     $services->set(BaseSerializer::class)
         ->public()


### PR DESCRIPTION
Hey,

if we are in prod mode without installed or enabled MakerBundle we get an errror:

```php
In ResolveClassPass.php line 41:
Service id "Timiki\Bundle\RpcServerBundle\Make\MakeMethod" looks like a FQCN but no corresponding 
class or interface exists. To resolve this ambiguity, please rename this service to a non-FQCN 
(e.g. using dots), or create the missing class or interface. 
```

This pr is checking for MakerBundle before register the MakeMethod service